### PR TITLE
ignore時のバグ修正 + RealProcess不在時のメッセージのフック用handler

### DIFF
--- a/src/proxy_sleep_handle.erl
+++ b/src/proxy_sleep_handle.erl
@@ -1,0 +1,85 @@
+%% @copyright 2015 Hinagiku Soranoba <soranoba@gmail.com>
+%% @doc RealProcessが存在しない場合にgen_serverのメッセージをハンドルする
+-module(proxy_sleep_handle).
+
+-behaviour(proxy).
+
+-export_type([
+              option/0
+             ]).
+
+%%----------------------------------------------------------------------------------------------------------------------
+%% 'proxy' Callback API
+%%----------------------------------------------------------------------------------------------------------------------
+-export([init/1, handle_arg/2, handle_up/2, handle_message/2, handle_down/2, terminate/2]).
+
+%%----------------------------------------------------------------------------------------------------------------------
+%% Macros & Records & Types
+%%----------------------------------------------------------------------------------------------------------------------
+
+-record(state,
+        {
+          is_running = false :: boolean(),
+          call               :: undefined | fun((term()) -> {reply, term()} | noreply),
+          cast               :: undefined | fun((term()) -> ok),
+          info               :: undefined | fun((term()) -> ok)
+        }).
+-type state()  :: #state{}.
+
+-type option() :: {call, fun((term()) -> {reply, term()} | noreply)} |
+                  {cast, fun((term()) -> ok)}                        |
+                  {info, fun((term()) -> ok)}.
+                  %% RealProcessが存在しない場合に実行するMessage処理
+
+%%----------------------------------------------------------------------------------------------------------------------
+%% 'proxy' Callback Functions
+%%----------------------------------------------------------------------------------------------------------------------
+
+%% @private
+-spec init([option()]) -> {ok, state()}.
+init(Options) ->
+    Call = proplists:get_value(call, Options, undefined),
+    Cast = proplists:get_value(cast, Options, undefined),
+    Info = proplists:get_value(info, Options, undefined),
+
+    State = #state{call = Call, cast = Cast, info = Info},
+    {ok, State}.
+
+%% @private
+-spec handle_arg(Args :: [term()], state()) -> {ok, Args :: [term()], state()}.
+handle_arg(Args, State) ->
+    {ok, Args, State}.
+
+%% @private
+-spec handle_up(RealProcess :: pid(), state()) -> {ok, state()}.
+handle_up(_Pid, State) ->
+    {ok, State#state{is_running = true}}.
+
+%% @private
+-spec handle_message(Message :: term(), state()) -> {ok, MessageOut :: term(), state()} | {stop, Reason :: term(), state()}.
+handle_message({'EXIT', _Pid, Reason}, State) ->
+    {stop, Reason, State};
+handle_message({'$gen_call', {From, Ref}, Request}, #state{is_running = false, call = CallFun} = State) when CallFun =/= undefined ->
+    _ = case CallFun(Request) of
+            {reply, Response} -> From ! {Ref, Response};
+            noreply           -> ok
+        end,
+    {ignore, State};
+handle_message({'$gen_cast', Request}, #state{is_running = false, cast = CastFun} = State) when CastFun =/= undefined ->
+    _ = CastFun(Request),
+    {ignore, State};
+handle_message(Request, #state{is_running = false, info = InfoFun} = State) when InfoFun =/= undefined ->
+    _ = InfoFun(Request),
+    {ignore, State};
+handle_message(Message, State) ->
+    {ok, Message, State}.
+
+%% @private
+-spec handle_down(Reason :: term(), state()) -> {ok, state()}.
+handle_down(_Reason, State) ->
+    {ok, State#state{is_running = false}}.
+
+%% @private
+-spec terminate(Reason :: term(), state()) -> ok.
+terminate(_Reason, _State) ->
+    ok.

--- a/src/proxy_sleep_handle.erl
+++ b/src/proxy_sleep_handle.erl
@@ -61,9 +61,9 @@ handle_up(_Pid, State) ->
 -spec handle_message(Message :: term(), state()) -> {ok, MessageOut :: term(), state()} | {stop, Reason :: term(), state()}.
 handle_message({'EXIT', _Pid, Reason}, State) ->
     {stop, Reason, State};
-handle_message({'$gen_call', {From, Ref}, Request}, #?STATE{is_running = false, call = CallFun} = State) when CallFun =/= undefined ->
+handle_message({'$gen_call', FromRef, Request}, #?STATE{is_running = false, call = CallFun} = State) when CallFun =/= undefined ->
     _ = case CallFun(Request) of
-            {reply, Response} -> gen_server:reply({From, Ref}, Response);
+            {reply, Response} -> gen_server:reply(FromRef, Response);
             noreply           -> ok
         end,
     {ignore, State};

--- a/test/proxy_sleep_handle_tests.erl
+++ b/test/proxy_sleep_handle_tests.erl
@@ -1,0 +1,75 @@
+%% coding: latin-1
+%% @copyright 2013-2015 DWANGO Co.,Ltd. All Rights Reserved.
+-module(proxy_sleep_handle_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ensureExited(Pid),
+        (fun() ->
+                 __Old = process_flag(trap_exit, true),
+                 __Ref = monitor(process, Pid),
+                 exit(Pid, normal),
+                 receive
+                     {'DOWN', __Ref, process, _, _} -> ?assert(true)
+                 after 50 ->
+                         ?assert(timeout)
+                 end,
+                 process_flag(trap_exit, __Old)
+         end)()).
+
+%%----------------------------------------------------------------------------------------------------------------------
+%% Unit Tests
+%%---------------------------------------------------------------------------------------------------------------------
+
+lifetime_test_() ->
+    {setup,
+     fun() ->
+             Call = fun(a) -> {reply, a};
+                       (_) -> noreply
+                    end,
+             Cast = fun({Pid, X}) -> Pid ! {cast, X}, ok end,
+             Info = fun({Pid, X}) -> Pid ! {info, X}, ok end,
+             StartTime = now_after(100, 0, 0),
+             proxy:spawn(timer, sleep, [infinity],
+                         [
+                          {proxy_sleep_handle, [{call, Call}, {cast, Cast}, {info, Info}]},
+                          {proxy_lifetime, [{start_time, StartTime}]}
+                         ])
+     end,
+     fun(Pid) ->
+             ?ensureExited(Pid)
+     end,
+     fun(Pid) ->
+             [
+              {"RealProcessが起動する前にcallがハンドリングできる",
+               fun() ->
+                       ?assertEqual(a, gen_server:call(Pid, a)),
+                       ?assertExit(_, gen_server:call(Pid, b, 10)),
+                       ?assert(is_process_alive(Pid))
+               end},
+              {"RealProcessが起動する前にcastがハンドリングできる",
+               fun() ->
+                       ?assertEqual(ok, gen_server:cast(Pid, {self(), a})),
+                       receive
+                           {cast, a} -> ?assert(true)
+                       after 1000 ->
+                               ?assert(timeout)
+                       end
+               end},
+              {"RealProcessが起動する前にinfoがハンドリングできる",
+               fun() ->
+                       Pid ! {self(), a},
+                       receive
+                           {info, a} -> ?assert(true)
+                       after 1000 ->
+                               ?assert(timeout)
+                       end
+               end}
+             ]
+     end}.
+
+%% @doc 現在時刻から指定時間後を返す.
+-spec now_after(integer(), integer(), integer()) -> erlang:timestamp().
+now_after(AddMega, AddSec, AddMicro) ->
+    {Mega, Sec, Micro} = now(),
+    {Mega + AddMega, Sec + AddSec, Micro + AddMicro}.


### PR DESCRIPTION
- ignoreを返すproxy以後にもproxyが存在する場合、以下のようなエラーが発生する不具合の修正
```
Error in process <0.80.0> with exit value: {function_clause,[{proxy_driver,'-invoke_proxy_list/3-fun-0-',[{proxy_lifetime,{proxy_lifetime,#Ref<0.0.0.933>,{1523,38741,233571},infinity,#Ref<0.0.0.936>,undefined}},{ignore,[{proxy_sleep_handle,{state,false,#Fun<proxy_sleep_handle_tests.17.14992437>,#Fun<proxy_sleep_handle_tests.18.14992437>,#Fun<proxy_sleep_handle_tests.19.14992437>}}]}],[{file,"src/proxy_driver.erl"},{line,111}]},{lists... 
```

- lifetimeを使用し、まだRealProcessが起動していない状態でメッセージが送られると異常終了する為、それを補う為のhandlerを作成