### PR TITLE
Amendment to `proxy_driver:invoke_handler_arg/3`

### DIFF
--- a/src/proxy.erl
+++ b/src/proxy.erl
@@ -41,7 +41,7 @@
 
 %% proxy_server で実行する関数の引数を処理する.
 -callback handle_arg([term()], proxy_state()) ->
-    {stop, term()} | {ok, [term()], proxy_state()} | {remove_proxy, [term()], proxy_state()} |
+    {stop, term(), proxy_state()} | {ok, [term()], proxy_state()} | {remove_proxy, [term()], proxy_state()} |
     {swap_proxy, [term()], term(), proxy_state(), module(), proxy_arg()} |
     {hibernate, [term()], proxy_state()}.
 

--- a/src/proxy_driver.erl
+++ b/src/proxy_driver.erl
@@ -140,7 +140,7 @@ invoke_init({Module, Arg}) ->
       Reason :: term().
 invoke_handle_arg(_Prev, Arg0, {Module, State0}) ->
     case Module:handle_arg(Arg0, State0) of
-        {stop, Reason}               -> {{stop, Reason}, {Module, State0}};
+        {stop, Reason, State1}       -> {{stop, Reason}, {Module, State1}};
         {hibernate, Arg1, State1}    -> {{hibernate, Arg1}, {Module, State1}};
         {ok, Arg1, State1}           -> {{ok, Arg1}, {Module, State1}};
         {remove_proxy, Arg1, State1} -> _ = remove_proxy({Module, State1}), {{ignore, Arg1}};

--- a/src/proxy_driver.erl
+++ b/src/proxy_driver.erl
@@ -140,7 +140,7 @@ invoke_init({Module, Arg}) ->
       Reason :: term().
 invoke_handle_arg(_Prev, Arg0, {Module, State0}) ->
     case Module:handle_arg(Arg0, State0) of
-        {stop, Reason, State1}       -> {{stop, Reason}, {Module, State1}};
+        {stop, Reason}               -> {{stop, Reason}, {Module, State0}};
         {hibernate, Arg1, State1}    -> {{hibernate, Arg1}, {Module, State1}};
         {ok, Arg1, State1}           -> {{ok, Arg1}, {Module, State1}};
         {remove_proxy, Arg1, State1} -> _ = remove_proxy({Module, State1}), {{ignore, Arg1}};


### PR DESCRIPTION
This PR attempts to slightly fix `proxy_driver:invoke_handle_arg/3`.

The current implementation of `proxy_driver:invoke_handle_arg/3` expects `Module:handle_arg/2` (where `Module` is a callback module of the behaviour `proxy`) to possibly return values of the form `{stop, Reason :: term(), State :: proxy:proxy_state()}`.

> https://github.com/sile/proxy/blob/master/src/proxy_driver.erl#L143
>
> ```erlang
> invoke_handle_arg(_Prev, Arg0, {Module, State0}) ->
>     case Module:handle_arg(Arg0, State0) of
>         {stop, Reason, State1}       -> {{stop, Reason}, {Module, State1}};
>         % ...
> ```

This seems, however, inconsistent with the behaviour `proxy`, which requires `Module:handle_arg/2` to be of the following spec:

> https://github.com/sile/proxy/blob/master/src/proxy.erl#L43-L46
>
> ```erlang
> %% proxy_server で実行する関数の引数を処理する.
> -callback handle_arg([term()], proxy_state()) ->
>     {stop, term()} | {ok, [term()], proxy_state()} | {remove_proxy, [term()], proxy_state()} |
>     {swap_proxy, [term()], term(), proxy_state(), module(), proxy_arg()} |
>     {hibernate, [term()], proxy_state()}.
> ```

That is, the behaviour says when a return value has `stop` as a tag, it must be of the form `{stop, Reason}`, not of `{stop, Reason, UpdatedState}`.

I would appreciate any comments or suggestions (especially because I do not really understand which of the behaviour `proxy` or the implementation of `proxy_driver:invoke_handle_arg/3` is truly intended).